### PR TITLE
Merge three collections in custom order with min selection logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,26 @@
+export function merge(
+  collection_1: number[],
+  collection_2: number[],
+  collection_3: number[]
+): number[] {
+    const mergedCollection: number[] = [];
+
+    let index1 = 0;
+    let index2 = collection_2.length - 1;
+    let index3 = 0;
+
+    while (index1 < collection_1.length || index2 >= 0 || index3 < collection_3.length) {
+        const candidates: { value: number; source: 'collection_1' | 'collection_2' | 'collection_3' }[] = [];
+        if (index1 < collection_1.length) {
+            candidates.push({value: collection_1[index1], source: 'collection_1' });
+        }
+        if (index2 >= 0) {
+            candidates.push({value: collection_2[index2], source: 'collection_2' });
+        }
+        if (index3 < collection_3.length) {
+            candidates.push({value: collection_3[index3], source: 'collection_3' });
+        }
+
+    }
+    return mergedCollection;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,70 @@
+type Source = "collection_1" | "collection_2" | "collection_3";
+
+interface Candidate {
+  value: number;
+  source: Source;
+}
+
+function getCandidates(
+  collection_1: number[],
+  collection_2: number[],
+  collection_3: number[],
+  index1: number,
+  index2: number,
+  index3: number
+): Candidate[] {
+  const candidates: Candidate[] = [];
+
+    const col_1 = collection_1[index1];
+    const col_2 = collection_2[index2];
+    const col_3 = collection_3[index3];
+
+    if (index1 < collection_1.length && col_1 !== undefined) {
+      candidates.push({ value: col_1, source: "collection_1" });
+    }
+    if (index2 >= 0 && col_2 !== undefined) {
+      candidates.push({ value: col_2, source: "collection_2" });
+    }
+    if (index3 < collection_3.length && col_3 !== undefined) {
+      candidates.push({ value: col_3, source: "collection_3" });
+    }
+
+  return candidates;
+}
+
 export function merge(
   collection_1: number[],
   collection_2: number[],
   collection_3: number[]
 ): number[] {
-    const mergedCollection: number[] = [];
+  const mergedCollection: number[] = [];
 
-    let index1 = 0;
-    let index2 = collection_2.length - 1;
-    let index3 = 0;
+  let index1 = 0;
+  let index2 = collection_2.length - 1;
+  let index3 = 0;
 
-    while (index1 < collection_1.length || index2 >= 0 || index3 < collection_3.length) {
-        const candidates: { value: number; source: 'collection_1' | 'collection_2' | 'collection_3' }[] = [];
-        if (index1 < collection_1.length) {
-            candidates.push({value: collection_1[index1], source: 'collection_1' });
-        }
-        if (index2 >= 0) {
-            candidates.push({value: collection_2[index2], source: 'collection_2' });
-        }
-        if (index3 < collection_3.length) {
-            candidates.push({value: collection_3[index3], source: 'collection_3' });
-        }
+  while (index1 < collection_1.length || index2 >= 0 || index3 < collection_3.length) {
+    const candidates = getCandidates(collection_1, collection_2, collection_3, index1, index2, index3);
 
+    if (candidates.length === 0) {
+      throw new Error("No valid candidates found");
     }
-    return mergedCollection;
+
+    const minCandidate = Math.min(...candidates.map((c) => c.value));
+    const minSource = candidates.find((c) => c.value === minCandidate)?.source;
+
+    if (!minSource) {
+      throw new Error("Failed to determine source of minimum value");
+    }
+
+    if (minSource === "collection_1") {
+      mergedCollection.push(collection_1[index1++]!);
+    } else if (minSource === "collection_2") {
+      mergedCollection.push(collection_2[index2--]!);
+    } else if (minSource === "collection_3") {
+      mergedCollection.push(collection_3[index3++]!);
+    }
+
+  }
+  return mergedCollection;
 }


### PR DESCRIPTION
### Summary

This PR implements a `merge` function that combines three number arrays (`collection_1`, `collection_2`, and `collection_3`) into a single sorted array using a custom logic. At each step, the function selects the minimum value among:
- the current element from `collection_1` (left to right),
- the current element from `collection_2` (right to left),
- the current element from `collection_3` (left to right).

### Details

- `getCandidates` is a helper function that returns valid candidates for merging based on current indices.
- The main `merge` function:
  - Initializes pointers for each collection.
  - Iteratively selects the minimum value among valid candidates.
  - Pushes the selected value into the result array and advances the corresponding pointer.
